### PR TITLE
[close #4] Swagger 기본 구성 추가

### DIFF
--- a/Network-Office/build.gradle
+++ b/Network-Office/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/Network-Office/src/main/java/dev/office/networkoffice/global/config/OpenApiConfig.java
+++ b/Network-Office/src/main/java/dev/office/networkoffice/global/config/OpenApiConfig.java
@@ -1,0 +1,32 @@
+package dev.office.networkoffice.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI createOpenApi() {
+        return new OpenAPI()
+                .info(getInfo())
+                .addServersItem(getLocalServer())
+                .components(new Components());
+    }
+
+    private Info getInfo() {
+        return new Info()
+                .title("Network-Office API Documents")
+                .version("v1")
+                .description("Network-Office API 명세");
+    }
+
+    private Server getLocalServer() {
+        return new Server().url("http://localhost:8080")
+                .description("Local Server");
+    }
+}

--- a/Network-Office/src/main/java/dev/office/networkoffice/global/config/WebSecurityConfig.java
+++ b/Network-Office/src/main/java/dev/office/networkoffice/global/config/WebSecurityConfig.java
@@ -1,4 +1,4 @@
-package dev.office.networkoffice.global;
+package dev.office.networkoffice.global.config;
 
 import java.util.List;
 


### PR DESCRIPTION
## 내용

> API 문서화 도구로 Swagger를 사용합니다.

## 관련 이슈

- #4 

## 선택 이유

- 개발 단계에서는 빠르게 변경될 수 있기 때문에 API 문서화가 쉬운 편에 속하는 도구를 선호합니다.
- 모두가 사용해본 경험이 있습니다.
- 단점을 보완할 패턴을 찾았습니다.
- 자세한 내용은 관련 이슈를 살펴봐주세요.