### PR TITLE
[close #13] 개발 환경 배포 파이프라인 구축

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -1,0 +1,50 @@
+name: cd-dev
+
+on:
+  push:
+    branches: develop
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./Network-Office
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+
+      - name: Sign in Dockerhub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build the Docker image
+        run: docker build -t ${{ secrets.DOCKER_HUB_USERNAME }}/${{ secrets.DOCKER_HUB_REPOSITORY }}:latest .
+
+      - name: Push the Docker image
+        run: docker push ${{ secrets.DOCKER_HUB_USERNAME }}/${{ secrets.DOCKER_HUB_REPOSITORY }}:latest
+
+  deploy:
+    needs: build
+    runs-on: self-hosted
+
+    steps:
+      - name: Move to the cd location
+        run: cd ~/app
+
+      - name: Docker Image pull
+        run: sudo docker pull ${{ secrets.DOCKER_HUB_USERNAME }}/${{ secrets.DOCKER_HUB_REPOSITORY }}:latest
+
+      - name: Docker Compose Restart
+        run: sudo docker-compose down && sudo docker-compose up -d

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -30,10 +30,10 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build the Docker image
-        run: docker build -t ${{ secrets.DOCKER_HUB_USERNAME }}/${{ secrets.DOCKER_HUB_REPOSITORY }}:latest .
+        run: docker build -t ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_HUB_REPOSITORY }}:latest .
 
       - name: Push the Docker image
-        run: docker push ${{ secrets.DOCKER_HUB_USERNAME }}/${{ secrets.DOCKER_HUB_REPOSITORY }}:latest
+        run: docker push ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_HUB_REPOSITORY }}:latest
 
   deploy:
     needs: build

--- a/Network-Office/.dockerignore
+++ b/Network-Office/.dockerignore
@@ -1,0 +1,1 @@
+.git/ .idea/ build/ .DS_Store

--- a/Network-Office/Dockerfile
+++ b/Network-Office/Dockerfile
@@ -1,0 +1,19 @@
+# Build layer
+FROM azul/zulu-openjdk-alpine:17 as build
+
+WORKDIR /app
+
+COPY build.gradle settings.gradle gradlew /app/
+COPY gradle /app/gradle
+COPY src /app/src
+
+RUN ./gradlew build -x test
+
+# Package layer
+FROM azul/zulu-openjdk-alpine:17-jre
+
+WORKDIR /app
+
+COPY --from=build /app/build/libs/*.jar /app/app.jar
+
+ENTRYPOINT ["java", "-jar", "-Duser.timezone=Asia/Seoul", "/app/app.jar"]

--- a/Network-Office/src/main/java/dev/office/networkoffice/global/config/OpenApiConfig.java
+++ b/Network-Office/src/main/java/dev/office/networkoffice/global/config/OpenApiConfig.java
@@ -4,17 +4,22 @@ import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class OpenApiConfig {
 
+    @Value("${swagger.server.dev}")
+    private String devServerUrl;
+
     @Bean
     public OpenAPI createOpenApi() {
         return new OpenAPI()
                 .info(getInfo())
                 .addServersItem(getLocalServer())
+                .addServersItem(getDevServer())
                 .components(new Components());
     }
 
@@ -28,5 +33,10 @@ public class OpenApiConfig {
     private Server getLocalServer() {
         return new Server().url("http://localhost:8080")
                 .description("Local Server");
+    }
+
+    private Server getDevServer() {
+        return new Server().url(devServerUrl)
+                .description("Dev Server");
     }
 }

--- a/Network-Office/src/main/java/dev/office/networkoffice/global/config/security/CsrfCookieFilter.java
+++ b/Network-Office/src/main/java/dev/office/networkoffice/global/config/security/CsrfCookieFilter.java
@@ -2,6 +2,7 @@ package dev.office.networkoffice.global.config.security;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.NonNull;
@@ -36,7 +37,12 @@ public class CsrfCookieFilter extends OncePerRequestFilter {
     }
 
     private boolean isClientCsrfTokenAbsent(HttpServletRequest request) {
-        return Arrays.stream(request.getCookies())
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return true;
+        }
+
+        return Arrays.stream(cookies)
                 .filter(cookie -> CSRF_COOKIE_NAME.equals(cookie.getName()))
                 .findFirst()
                 .isEmpty();

--- a/Network-Office/src/main/resources/application.yml
+++ b/Network-Office/src/main/resources/application.yml
@@ -1,6 +1,5 @@
+# Common
 spring:
-  profiles:
-    active: local
   application:
     name: Network-Office
 
@@ -9,18 +8,15 @@ spring:
       enabled: true
       path: /h2-console
 
-  datasource:
-    url: jdbc:h2:mem:test
-    username: sa
-    password:
-    driver-class-name: org.h2.Driver
-
   jpa:
     hibernate:
       ddl-auto: create
     properties:
       hibernate:
         format_sql: true
+
+logging.level:
+  org.hibernate.SQL: debug
 
 oauth:
   kakao:
@@ -29,5 +25,47 @@ oauth:
     user-information-request-url: ${OAUTH_KAKAO_USER_INFORMATION_REQUEST_URI}
     rest-api-key: ${OAUTH_KAKAO_REST_API_KEY}
 
-logging.level:
-  org.hibernate.SQL: debug
+swagger:
+  server:
+    dev: ${DEV_SERVER_URL}
+
+---
+# Local
+spring:
+  config:
+    activate:
+      on-profile: local
+  datasource:
+    url: jdbc:h2:mem:testdb
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  h2:
+    console:
+      path: /h2-console
+  jpa:
+    hibernate:
+      ddl-auto: create
+
+---
+# Dev
+spring:
+  config:
+    activate:
+      on-profile: dev
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: ${DB_DRIVER}
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL8Dialect
+
+  h2:
+    console:
+      enabled: false

--- a/Network-Office/src/test/resources/application.yml
+++ b/Network-Office/src/test/resources/application.yml
@@ -1,6 +1,7 @@
 spring:
-  profiles:
-    active: test
+  config:
+    activate:
+      on-profile: test
   application:
     name: Network-Office
 
@@ -28,6 +29,10 @@ oauth:
     access-token-request-url: ${OAUTH_KAKAO_ACCESS_TOKEN_REQUEST_URI}
     user-information-request-url: ${OAUTH_KAKAO_USER_INFORMATION_REQUEST_URI}
     rest-api-key: ${OAUTH_KAKAO_REST_API_KEY}
+
+server:
+  dev:
+    domain: ${DEV_SERVER_DOMAIN}
 
 logging.level:
   org.hibernate.SQL: debug


### PR DESCRIPTION
# 관련 이슈

> 개발 환경 배포 파이프라인을 구축합니다.

- #13 

## 요약

<img width="1331" alt="image" src="https://github.com/user-attachments/assets/0aaa0f53-6aa9-48c6-b859-3dc29656dd2a">

- 위 그림과 같이 자동 배포 파이프라인을 구축합니다.

## 흐름

1. `develop` 브랜치에 작업 결과가 `push` 됩니다.
2. 이를 감지하여 `cd-dev` 실행됩니다. (GitHub Actions)
3. GitHub 자체 서버로 docker image `build and push`가 진행됩니다. (Docker Hub)
4. 이후 `self-hosted-runner`를 통해 배포 서버에서 나머지 작업이 수행됩니다.
5. 나머지 작업은 변경사항 반영 및 서버 재시작이 포함되어 있습니다.

## 배포 환경

- EC2 : `t2.micro`, `Amazon Linux`
- RDS : `db.t3.micro`, `MySQL 8`
- traefik : `v3.1`

AWS 인프라에서는 과도한 요금 부과를 막기 위해 프리티어 기준을 준수했습니다.

## 추가 내용

- 배포 환경에서는 `MySQL`을 사용하기 때문에 Spring Profile 설정을 위한 yml 구성이 변경됩니다.
- 원활한 환경을 위해 현재는 1개의 서버 컨테이너만 실행되고 있습니다. (그림의 3개는 이해를 위한 구성이며, 쉽게 추가할 수 있습니다.)
- 환경 변수는 정리해서 직접 전달할 예정입니다.
- `Swagger` 문서의 Server가 추가되었습니다. 상단의 Servers 목록에서 로컬 서버와 배포 서버를 선택할 수 있습니다.

<img width="421" alt="image" src="https://github.com/user-attachments/assets/af608695-8dd1-4bd3-be18-3f154b3ca858">

### Spring Profile 적용 방법
<img width="550" alt="image" src="https://github.com/user-attachments/assets/33c29d74-01fb-4a21-b58b-012008841532">

- 이처럼 ide의 구성 설정을 통해 profile을 설정할 수 있습니다. 배포 환경의 profile은 `dev`입니다.
- 또는 `Add JVM Option`을 통해 `-Dspring.profiles.active=dev`를 추가하는 방법도 있습니다.