### PR TITLE
[close #17] 개발 환경 세션 저장소 분리 및 Profile 수정

### DIFF
--- a/Network-Office/build.gradle
+++ b/Network-Office/build.gradle
@@ -27,6 +27,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.session:spring-session-data-redis'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'

--- a/Network-Office/src/main/resources/application.yml
+++ b/Network-Office/src/main/resources/application.yml
@@ -1,7 +1,13 @@
-# Common
+# Default, Local
 spring:
   application:
     name: Network-Office
+
+  datasource:
+    url: jdbc:h2:mem:testdb
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
 
   h2:
     console:
@@ -15,8 +21,19 @@ spring:
       hibernate:
         format_sql: true
 
-logging.level:
-  org.hibernate.SQL: debug
+  # Local 환경 Redis 의존성 제외
+  # session.store-type 옵션이 deprecated, 임시로 사용
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration
+
+server:
+  servlet:
+    session:
+      cookie:
+        secure: false
+        same-site: lax
 
 oauth:
   kakao:
@@ -29,23 +46,8 @@ swagger:
   server:
     dev: ${DEV_SERVER_URL}
 
----
-# Local
-spring:
-  config:
-    activate:
-      on-profile: local
-  datasource:
-    url: jdbc:h2:mem:testdb
-    username: sa
-    password:
-    driver-class-name: org.h2.Driver
-  h2:
-    console:
-      path: /h2-console
-  jpa:
-    hibernate:
-      ddl-auto: create
+logging.level:
+  org.hibernate.SQL: debug
 
 ---
 # Dev
@@ -53,6 +55,7 @@ spring:
   config:
     activate:
       on-profile: dev
+
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}
@@ -69,3 +72,19 @@ spring:
   h2:
     console:
       enabled: false
+
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      password: ${REDIS_PASSWORD}
+
+  session:
+    redis:
+      namespace: ${REDIS_SESSION_NAMESPACE}
+
+server:
+  servlet:
+    session:
+      cookie:
+        secure: true


### PR DESCRIPTION
## 내용

> 개발 환경의 세션 저장소를 분리합니다. (로컬 환경은 톰캣 세션을 사용합니다.)

## 흐름

<img width="1255" alt="image" src="https://github.com/user-attachments/assets/1cc0764d-4d08-4fdf-a453-17d6b1d625be">

- `ElastiCache` : `Redis` 엔진을 사용합니다. 프리티어를 위해 `t2.micro`를 사용합니다.
- `Profile 분리` : 로컬 환경에서는 Profile을 지정하지 않아도 됩니다.

## 기타

- ElastiCache 클러스터 모드를 활성화하면, 가용성을 높일 수 있습니다. (비용 발생)
- RDS와는 다르게 외부에서는 세션 저장소를 접근할 수 없습니다. 내부 네트워크로만 (EC2 인스턴스) 접근 가능합니다.