### PR TITLE
사용자 프로필 관리 기능 구현

### DIFF
--- a/Network-Office/src/main/java/dev/office/networkoffice/user/controller/UserController.java
+++ b/Network-Office/src/main/java/dev/office/networkoffice/user/controller/UserController.java
@@ -1,10 +1,15 @@
 package dev.office.networkoffice.user.controller;
 
 import dev.office.networkoffice.user.controller.docs.UserApiDocs;
+import dev.office.networkoffice.user.dto.UpdateDescription;
+import dev.office.networkoffice.user.dto.UpdateDisplayName;
+import dev.office.networkoffice.user.dto.UpdateProfileImage;
 import dev.office.networkoffice.user.dto.UserInfo;
 import dev.office.networkoffice.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -21,5 +26,25 @@ public class UserController implements UserApiDocs {
     public UserInfo profile(Principal principal) {
         Long userId = Long.parseLong(principal.getName());
         return userService.profile(userId);
+    }
+
+    @PatchMapping("profile/display-name")
+    public void updateDisplayName(Principal principal,
+                                  @RequestBody UpdateDisplayName request) {
+        Long userId = Long.parseLong(principal.getName());
+        userService.updateDisplayName(userId, request);
+    }
+
+    @PatchMapping("profile/image")
+    public void updateProfileImage(Principal principal,
+                                   @RequestBody UpdateProfileImage request) {
+        Long userId = Long.parseLong(principal.getName());
+        userService.updateProfileImage(userId, request);
+    }
+
+    @PatchMapping("profile/description")
+    public void updateDescription(Principal principal, UpdateDescription request) {
+        Long userId = Long.parseLong(principal.getName());
+        userService.updateDescription(userId, request);
     }
 }

--- a/Network-Office/src/main/java/dev/office/networkoffice/user/controller/docs/UserApiDocs.java
+++ b/Network-Office/src/main/java/dev/office/networkoffice/user/controller/docs/UserApiDocs.java
@@ -1,5 +1,8 @@
 package dev.office.networkoffice.user.controller.docs;
 
+import dev.office.networkoffice.user.dto.UpdateDescription;
+import dev.office.networkoffice.user.dto.UpdateDisplayName;
+import dev.office.networkoffice.user.dto.UpdateProfileImage;
 import dev.office.networkoffice.user.dto.UserInfo;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -23,4 +26,55 @@ public interface UserApiDocs {
             )
     })
     UserInfo profile(Principal principal);
+
+    @Operation(summary = "내 닉네임 변경")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "요청이 정상적으로 처리되었을 때"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청이 들어왔을 때"
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증되지 않은 사용자가 요청했을 때"
+            )
+    })
+    void updateDisplayName(Principal principal, UpdateDisplayName request);
+
+    @Operation(summary = "내 프로필 이미지 변경")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "요청이 정상적으로 처리되었을 때"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청이 들어왔을 때"
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증되지 않은 사용자가 요청했을 때"
+            )
+    })
+    void updateProfileImage(Principal principal, UpdateProfileImage request);
+
+    @Operation(summary = "내 상태 메시지 변경")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "요청이 정상적으로 처리되었을 때"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청이 들어왔을 때"
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증되지 않은 사용자가 요청했을 때"
+            )
+    })
+    void updateDescription(Principal principal, UpdateDescription request);
 }

--- a/Network-Office/src/main/java/dev/office/networkoffice/user/dto/UpdateDescription.java
+++ b/Network-Office/src/main/java/dev/office/networkoffice/user/dto/UpdateDescription.java
@@ -1,0 +1,9 @@
+package dev.office.networkoffice.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record UpdateDescription(
+        @JsonProperty("description")
+        String description
+) {
+}

--- a/Network-Office/src/main/java/dev/office/networkoffice/user/dto/UpdateDisplayName.java
+++ b/Network-Office/src/main/java/dev/office/networkoffice/user/dto/UpdateDisplayName.java
@@ -1,0 +1,9 @@
+package dev.office.networkoffice.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record UpdateDisplayName(
+        @JsonProperty("display_name")
+        String displayName
+) {
+}

--- a/Network-Office/src/main/java/dev/office/networkoffice/user/dto/UpdateProfileImage.java
+++ b/Network-Office/src/main/java/dev/office/networkoffice/user/dto/UpdateProfileImage.java
@@ -1,0 +1,9 @@
+package dev.office.networkoffice.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record UpdateProfileImage(
+        @JsonProperty("profile_image_url")
+        String profileImageUrl
+) {
+}

--- a/Network-Office/src/main/java/dev/office/networkoffice/user/dto/UserInfo.java
+++ b/Network-Office/src/main/java/dev/office/networkoffice/user/dto/UserInfo.java
@@ -5,23 +5,26 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public record UserInfo(
         @JsonProperty("id")
         Long id,
-        @JsonProperty("nickname")
-        String nickname,
+        @JsonProperty("display_name")
+        String displayName,
         @JsonProperty("social_id")
         String socialId,
         @JsonProperty("social_type")
         String socialType,
         @JsonProperty("profile_image_url")
         String profileImageUrl,
+        @JsonProperty("description")
+        String description,
         @JsonProperty("phone_number")
         String phoneNumber
 ) {
     public static UserInfo create(Long id,
-                                  String nickname,
+                                  String displayName,
                                   String socialId,
                                   String socialType,
                                   String profileImageUrl,
+                                  String description,
                                   String phoneNumber) {
-        return new UserInfo(id, nickname, socialId, socialType, profileImageUrl, phoneNumber);
+        return new UserInfo(id, displayName, socialId, socialType, profileImageUrl, description, phoneNumber);
     }
 }

--- a/Network-Office/src/main/java/dev/office/networkoffice/user/entity/OAuthInfo.java
+++ b/Network-Office/src/main/java/dev/office/networkoffice/user/entity/OAuthInfo.java
@@ -20,6 +20,8 @@ public class OAuthInfo {
     @Column(name = "social_type")
     private SocialType socialType;
 
+    // 소셜 로그인을 통해 가입한 사용자의 소셜 계정 닉네임
+    // 서비스의 닉네임과 다릅니다.
     @Column(name = "nickname")
     private String nickname;
 

--- a/Network-Office/src/main/java/dev/office/networkoffice/user/entity/Profile.java
+++ b/Network-Office/src/main/java/dev/office/networkoffice/user/entity/Profile.java
@@ -12,7 +12,7 @@ import org.springframework.util.Assert;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Profile {
 
-    private static final String INIT_EMPTY_VALUE = "";
+    private static final String INIT_EMPTY_VALUE = null;
 
     @Column(name = "display_name", unique = true)
     private String displayName;
@@ -36,6 +36,9 @@ public class Profile {
 
     protected void updateDisplayName(String displayName) {
         Assert.hasText(displayName, "닉네임은 필수입니다.");
+        if (displayName.length() < 2 || displayName.length() > 20) {
+            throw new IllegalArgumentException("닉네임은 2자 이상 20자 이하여야 합니다.");
+        }
         this.displayName = displayName;
     }
 

--- a/Network-Office/src/main/java/dev/office/networkoffice/user/entity/Profile.java
+++ b/Network-Office/src/main/java/dev/office/networkoffice/user/entity/Profile.java
@@ -1,0 +1,51 @@
+package dev.office.networkoffice.user.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.util.Assert;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Profile {
+
+    private static final String INIT_EMPTY_VALUE = "";
+
+    @Column(name = "display_name", unique = true)
+    private String displayName;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @Column(name = "description")
+    private String description;
+
+    private Profile(String displayName, String imageUrl, String description) {
+        this.displayName = displayName;
+        this.imageUrl = imageUrl;
+        this.description = description;
+    }
+
+    public static Profile createNewProfile(String profileImageUrl) {
+        Assert.hasText(profileImageUrl, "프로필 이미지 URL은 필수입니다.");
+        return new Profile(INIT_EMPTY_VALUE, profileImageUrl, INIT_EMPTY_VALUE);
+    }
+
+    protected void updateDisplayName(String displayName) {
+        Assert.hasText(displayName, "닉네임은 필수입니다.");
+        this.displayName = displayName;
+    }
+
+    protected void updateProfileImageUrl(String profileImageUrl) {
+        Assert.hasText(profileImageUrl, "프로필 이미지 URL은 필수입니다.");
+        this.imageUrl = profileImageUrl;
+    }
+
+    protected void updateDescription(String description) {
+        Assert.notNull(description, "자기소개는 필수입니다.");
+        this.description = description;
+    }
+}

--- a/Network-Office/src/main/java/dev/office/networkoffice/user/entity/User.java
+++ b/Network-Office/src/main/java/dev/office/networkoffice/user/entity/User.java
@@ -27,8 +27,8 @@ public class User extends BaseTimeEntity {
     @Embedded
     private OAuthInfo oAuthInfo;
 
-    @Column(name = "profile_image_url")
-    private String profileImageUrl;
+    @Embedded
+    private Profile profile;
 
     @Column(name = "phone_number", unique = true)
     private String phoneNumber;
@@ -36,16 +36,16 @@ public class User extends BaseTimeEntity {
     @Column(name = "is_verified")
     private boolean isVerified;
 
-    private User(OAuthInfo oAuthInfo, String profileImageUrl) {
+    private User(OAuthInfo oAuthInfo, Profile profile) {
         this.oAuthInfo = oAuthInfo;
-        this.profileImageUrl = profileImageUrl;
+        this.profile = profile;
         this.isVerified = false;
     }
 
     public static User createNewUserWithOAuth(OAuthInfo oAuthInfo, String profileImageUrl) {
         Assert.notNull(oAuthInfo, "OAuth 정보는 필수입니다.");
-        Assert.hasText(profileImageUrl, "프로필 이미지 URL은 필수입니다.");
-        return new User(oAuthInfo, profileImageUrl);
+        Profile profile = Profile.createNewProfile(profileImageUrl);
+        return new User(oAuthInfo, profile);
     }
 
     public void verifyPhoneNumber(String phoneNumber) {
@@ -53,5 +53,17 @@ public class User extends BaseTimeEntity {
         Assert.isTrue(!isVerified, "이미 인증된 사용자입니다.");
         this.phoneNumber = phoneNumber;
         this.isVerified = true;
+    }
+
+    public void updateDisplayName(String displayName) {
+        profile.updateDisplayName(displayName);
+    }
+
+    public void updateProfileImageUrl(String profileImageUrl) {
+        profile.updateProfileImageUrl(profileImageUrl);
+    }
+
+    public void updateDescription(String description) {
+        profile.updateDescription(description);
     }
 }

--- a/Network-Office/src/main/java/dev/office/networkoffice/user/repository/UserRepository.java
+++ b/Network-Office/src/main/java/dev/office/networkoffice/user/repository/UserRepository.java
@@ -23,4 +23,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findBySocialLogin(@Param("socialId") String socialId, @Param("socialType") SocialType socialType);
 
     boolean existsByPhoneNumber(String phoneNumber);
+
+    boolean existsByProfileDisplayName(String displayName);
 }

--- a/Network-Office/src/main/java/dev/office/networkoffice/user/service/UserService.java
+++ b/Network-Office/src/main/java/dev/office/networkoffice/user/service/UserService.java
@@ -1,5 +1,8 @@
 package dev.office.networkoffice.user.service;
 
+import dev.office.networkoffice.user.dto.UpdateDescription;
+import dev.office.networkoffice.user.dto.UpdateDisplayName;
+import dev.office.networkoffice.user.dto.UpdateProfileImage;
 import dev.office.networkoffice.user.dto.UserInfo;
 import dev.office.networkoffice.user.entity.User;
 import dev.office.networkoffice.user.repository.UserRepository;
@@ -27,11 +30,37 @@ public class UserService {
     private UserInfo responseUserInfo(User findUser) {
         return UserInfo.create(
                 findUser.getId(),
-                findUser.getOAuthInfo().getNickname(),
+                findUser.getProfile().getDisplayName(),
                 findUser.getOAuthInfo().getSocialId(),
                 findUser.getOAuthInfo().getSocialType().name(),
-                findUser.getProfileImageUrl(),
+                findUser.getProfile().getImageUrl(),
+                findUser.getProfile().getDescription(),
                 findUser.getPhoneNumber()
         );
+    }
+
+    @Transactional
+    public void updateDisplayName(Long userId, UpdateDisplayName request) {
+        User findUser = findUserById(userId);
+        checkDuplicateDisplayName(request);
+        findUser.updateDisplayName(request.displayName());
+    }
+
+    private void checkDuplicateDisplayName(UpdateDisplayName request) {
+        if (userRepository.existsByProfileDisplayName(request.displayName())) {
+            throw new IllegalArgumentException("이미 사용중인 닉네임입니다.");
+        }
+    }
+
+    @Transactional
+    public void updateProfileImage(Long userId, UpdateProfileImage request) {
+        User findUser = findUserById(userId);
+        findUser.updateProfileImageUrl(request.profileImageUrl());
+    }
+
+    @Transactional
+    public void updateDescription(Long userId, UpdateDescription request) {
+        User findUser = findUserById(userId);
+        findUser.updateDescription(request.description());
     }
 }

--- a/Network-Office/src/test/java/dev/office/networkoffice/user/entity/UserTest.java
+++ b/Network-Office/src/test/java/dev/office/networkoffice/user/entity/UserTest.java
@@ -88,4 +88,85 @@ class UserTest {
         // when, then
         assertThrows(IllegalArgumentException.class, () -> user.verifyPhoneNumber("01012345678"));
     }
+
+    @Test
+    @DisplayName("DisplayName을 수정하면 사용자의 닉네임이 변경되어야 한다.")
+    void shouldChangeDisplayName() {
+        // given
+        OAuthInfo oAuthInfo = OAuthInfo.createForKakao("1", "test");
+        User user = User.createNewUserWithOAuth(oAuthInfo, "http://test.com");
+        String testNickname = "testNickname";
+
+        // when
+        user.updateDisplayName(testNickname);
+
+        // then
+        assertEquals(testNickname, user.getProfile().getDisplayName());
+    }
+
+    @Test
+    @DisplayName("수정할 DisplayName이 없으면 예외가 발생해야 한다.")
+    void shouldThrowExceptionWhenUpdateDisplayNameIsEmptyOrNull() {
+        // given
+        OAuthInfo oAuthInfo = OAuthInfo.createForKakao("1", "test");
+        User user = User.createNewUserWithOAuth(oAuthInfo, "http://test.com");
+
+        // when, then
+        assertThrows(IllegalArgumentException.class, () -> user.updateDisplayName(""));
+        assertThrows(IllegalArgumentException.class, () -> user.updateDisplayName(null));
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 URL을 수정하면 사용자의 프로필 이미지 URL이 변경되어야 한다.")
+    void shouldChangeProfileImageUrl() {
+        // given
+        OAuthInfo oAuthInfo = OAuthInfo.createForKakao("1", "test");
+        User user = User.createNewUserWithOAuth(oAuthInfo, "http://test1.com");
+        String testProfileImageUrl = "http://test2.com";
+
+        // when
+        user.updateProfileImageUrl(testProfileImageUrl);
+
+        // then
+        assertEquals(testProfileImageUrl, user.getProfile().getImageUrl());
+    }
+
+    @Test
+    @DisplayName("수정할 프로필 이미지 URL이 없으면 예외가 발생해야 한다.")
+    void shouldThrowExceptionWhenUpdateProfileImageUrlIsEmptyOrNull() {
+        // given
+        OAuthInfo oAuthInfo = OAuthInfo.createForKakao("1", "test");
+        User user = User.createNewUserWithOAuth(oAuthInfo, "http://test.com");
+
+        // when, then
+        assertThrows(IllegalArgumentException.class, () -> user.updateProfileImageUrl(""));
+        assertThrows(IllegalArgumentException.class, () -> user.updateProfileImageUrl(null));
+    }
+
+    @Test
+    @DisplayName("자기소개를 수정하면 사용자의 자기소개가 변경되어야 한다.")
+    void shouldChangeDescription() {
+        // given
+        OAuthInfo oAuthInfo = OAuthInfo.createForKakao("1", "test");
+        User user = User.createNewUserWithOAuth(oAuthInfo, "http://test.com");
+        String testDescription = "testDescription";
+
+        // when
+        user.updateDescription(testDescription);
+
+        // then
+        assertEquals(testDescription, user.getProfile().getDescription());
+    }
+
+    @Test
+    @DisplayName("수정할 자기소개가 없으면 예외가 발생해야 한다.")
+    void shouldThrowExceptionWhenUpdateDescriptionIsEmptyOrNull() {
+        // given
+        OAuthInfo oAuthInfo = OAuthInfo.createForKakao("1", "test");
+        User user = User.createNewUserWithOAuth(oAuthInfo, "http://test.com");
+
+        // when, then
+        assertThrows(IllegalArgumentException.class, () -> user.updateDescription(""));
+        assertThrows(IllegalArgumentException.class, () -> user.updateDescription(null));
+    }
 }

--- a/Network-Office/src/test/java/dev/office/networkoffice/user/entity/UserTest.java
+++ b/Network-Office/src/test/java/dev/office/networkoffice/user/entity/UserTest.java
@@ -117,6 +117,18 @@ class UserTest {
     }
 
     @Test
+    @DisplayName("수정할 DisplayName이 2자 미만이거나 20자를 초과하면 예외가 발생해야 한다.")
+    void shouldThrowExceptionWhenUpdateDisplayNameIsLessThanTwoOrMoreThanTwenty() {
+        // given
+        OAuthInfo oAuthInfo = OAuthInfo.createForKakao("1", "test");
+        User user = User.createNewUserWithOAuth(oAuthInfo, "http://test.com");
+
+        // when, then
+        assertThrows(IllegalArgumentException.class, () -> user.updateDisplayName("a"));
+        assertThrows(IllegalArgumentException.class, () -> user.updateDisplayName("123456789012345678901"));
+    }
+
+    @Test
     @DisplayName("프로필 이미지 URL을 수정하면 사용자의 프로필 이미지 URL이 변경되어야 한다.")
     void shouldChangeProfileImageUrl() {
         // given
@@ -159,14 +171,13 @@ class UserTest {
     }
 
     @Test
-    @DisplayName("수정할 자기소개가 없으면 예외가 발생해야 한다.")
+    @DisplayName("수정할 자기소개가 null이면 예외가 발생해야 한다.")
     void shouldThrowExceptionWhenUpdateDescriptionIsEmptyOrNull() {
         // given
         OAuthInfo oAuthInfo = OAuthInfo.createForKakao("1", "test");
         User user = User.createNewUserWithOAuth(oAuthInfo, "http://test.com");
 
         // when, then
-        assertThrows(IllegalArgumentException.class, () -> user.updateDescription(""));
         assertThrows(IllegalArgumentException.class, () -> user.updateDescription(null));
     }
 }


### PR DESCRIPTION
## 요약

> 서비스에서 보여지는 사용자의 정보를 프로필로 분리하고, 관리하는 API를 구현했습니다.

## 내용

- 프로필 추가
- 프로필 관리 API 구현
- 테스트 코드 추가

## 프로필

- 닉네임, 프로필 사진, 자기소개를 의미합니다.
- 여기서 닉네임 대신 `displayName` 라고 사용합니다.
- `nickname`필드는 OAuth 계정의 이름을 의미합니다. 즉, 서비스에서 사용자를 표시하는 이름은 `displayName`입니다.
- 프로필은 값 타입으로 선언되어 있습니다. `Profile`

### 닉네임 중복 관련

- 오해를 방지하기 위해 닉네임 중복을 허용하지 않습니다.
- 중복을 허용하지 않으면서, OAuth 계정의 닉네임(주로 사용자의 실명)을 서비스 닉네임으로 사용할 수 없었습니다. (동명이인 등)
- UUID나 해시태그와 같이 고유하게 만드는 것도 생각해봤지만, 이는 디자인을 해칠 수 있기 때문에 보류되었습니다.
- 따라서 서비스에 표시될 이름을 따로 추가했습니다.

### 흐름 예시

1. OAuth 기반 로그인을 수행하면 `displayName` 과 `description`이 비어 있습니다.
2. 비어있는 경우 서비스에서 사용될 이름(필수)과 자기소개(선택)란을 채울 수 있게 해주시면 될 것 같습니다. @khj0426 